### PR TITLE
common.py - implemented 'mqtt_root' as identifier

### DIFF
--- a/custom_components/openwb2mqtt/common.py
+++ b/custom_components/openwb2mqtt/common.py
@@ -22,7 +22,7 @@ class OpenWBBaseEntity:
         """Return the device information."""
         return DeviceInfo(
             name=self.device_friendly_name,
-            identifiers={(DOMAIN, self.device_friendly_name)},
+            identifiers={(DOMAIN, self.device_friendly_name, self.mqtt_root)},
             manufacturer=MANUFACTURER,
             model=MODEL,
         )


### PR DESCRIPTION
Implemented 'mqtt_root' as identifier to use more than one openWB instance in Home Assistant

Without it I was not able to create different devices with the same id, but different MQTT root topics.
