### PR TITLE
Added reading of Vehicle ID endpoint on openWB Pro that shows the MAC of the connected vehicle.

### DIFF
--- a/custom_components/openwb2mqtt/MQTT-Topics.txt
+++ b/custom_components/openwb2mqtt/MQTT-Topics.txt
@@ -44,6 +44,7 @@ SENSORS_PER_CHARGEPOINT
                 key="get/connected_vehicle/config",
                 key="get/connected_vehicle/soc",
                 key="get/rfid",
+                key="get/vehicle_id",
 
 SENSORS_PER_COUNTER
         mqttTopicCurrentValue = {mqttRoot}/counter/{deviceID}/get/{key}

--- a/custom_components/openwb2mqtt/const.py
+++ b/custom_components/openwb2mqtt/const.py
@@ -483,6 +483,15 @@ SENSORS_PER_CHARGEPOINT = [
         entity_registry_enabled_default=False,
     ),
     openwbSensorEntityDescription(
+        key="get/vehicle_id",
+        name="Vehicle ID",
+        device_class=None,
+        native_unit_of_measurement=None,
+        icon="mdi:tag-multiple",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    openwbSensorEntityDescription(
         key="get/connected_vehicle/soc",
         name="Geladene Entfernung",
         device_class=None,


### PR DESCRIPTION
Can be used for identifying  and charging VW on openWB Pro, which changes their MAC on every connection