### PR TITLE
feat: Add ability to set price-based charging max value

### DIFF
--- a/custom_components/openwb2mqtt/const.py
+++ b/custom_components/openwb2mqtt/const.py
@@ -917,6 +917,25 @@ NUMBERS_PER_CHARGEPOINT = [
         is not None
         else None,
     ),
+    # Dynamic number for price-based charging maximum price
+    openwbDynamicNumberEntityDescription(
+        key="price_based_charging_max_price",
+        name="Max. Preis (Strompreisbasiertes Laden)",
+        native_unit_of_measurement="ct/kWh",
+        device_class=None,
+        icon="mdi:currency-eur",
+        native_min_value=0.0,
+        native_max_value=1000.0,
+        native_step=0.1,
+        entity_category=EntityCategory.CONFIG,
+        # This is a template that will be formatted with the charge template ID for reading the current value
+        mqttTopicTemplate="{mqtt_root}/vehicle/template/charge_template/{charge_template_id}",
+        # This is a template that will be formatted with the charge template ID for setting the current value
+        mqttTopicCommandTemplate="{mqtt_root}/set/vehicle/template/charge_template/{charge_template_id}/et/max_price",
+        # Extract the current value from the JSON payload
+        value_fn=lambda x: _safeNestedGet(x, "et", "max_price") * 100000,
+        convert_before_publish_fn=lambda x: x / 100000.0
+    ),
     # openWBNumberEntityDescription(
     #     key="pv_charging_min_current",
     #     name="Ladestromvorgabe (PV Laden)",


### PR DESCRIPTION
Add the ability to set the max price for price-based charging as discussed in #48. I've tested this in my local homeassistant setup and it seems to work. I decided to format the number the same way as in the OpenWB dashboard instead of how it's stored in JSON. I also made the steps bigger, as steps of 0.01 in OpenWB seem a bit too small. I'm open to changing both of these.

This doesn't include support for enabling/disabling price-based charging yet, also as discussed in #48.